### PR TITLE
fix: Corrected derived `From` implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,9 +141,8 @@ assert!(settings.debug)
 - The `prefix` is applied per field or for the entire struct, but is ignored if `#[config(key = "_")]` is used.
 - All configuration structs must implement [`Default`](https://doc.rust-lang.org/std/default/trait.Default.html).
 - Custom types used in configuration struct fields must implement [`Deserialize`](https://docs.rs/serde/latest/serde/trait.Deserialize.html),
-  [`Clone`](https://doc.rust-lang.org/std/clone/trait.Clone.html),
-  [`Debug`](https://doc.rust-lang.org/std/fmt/trait.Debug.html) and
-  [`Default`](https://doc.rust-lang.org/std/default/trait.Default.html).
+  [`Clone`](https://doc.rust-lang.org/std/clone/trait.Clone.html), and
+  [`Debug`](https://doc.rust-lang.org/std/fmt/trait.Debug.html).
 - [`Option`](https://doc.rust-lang.org/std/option/enum.Option.html) is not currently compatible with `#[config(nest)]`
   on types that implement [`Confgr`](https://docs.rs/confgr/latest/confgr/core/trait.Confgr.html).
 

--- a/crates/confgr_derive/src/convert.rs
+++ b/crates/confgr_derive/src/convert.rs
@@ -22,7 +22,7 @@ pub fn generate_conversion_impl(
             }
         } else {
             quote! {
-                #field_name: #LAYER_PARAMETER.#field_name.unwrap_or_default(),
+                #field_name: #LAYER_PARAMETER.#field_name.unwrap_or_else(|| #name::default().#field_name),
             }
         }
     });

--- a/crates/confgr_derive/src/merge.rs
+++ b/crates/confgr_derive/src/merge.rs
@@ -67,7 +67,9 @@ pub fn generate_layer(
         #[automatically_derived]
         impl Default for #layer_name {
            fn default() -> Self {
-            #name::default().into()
+                #name {
+                    ..::core::default::Default::default()
+                }.into()
             }
         }
 

--- a/crates/confgr_derive/src/merge.rs
+++ b/crates/confgr_derive/src/merge.rs
@@ -67,9 +67,7 @@ pub fn generate_layer(
         #[automatically_derived]
         impl Default for #layer_name {
            fn default() -> Self {
-                #name {
-                    ..::core::default::Default::default()
-                }.into()
+                #name::default().into()
             }
         }
 

--- a/tests/foreign.rs
+++ b/tests/foreign.rs
@@ -31,4 +31,3 @@ fn test_non_default_foreign_type_is_valid() {
     let config = TestConfig::load_config();
     assert_eq!(config.foreign_type.value, "default_value");
 }
-

--- a/tests/foreign.rs
+++ b/tests/foreign.rs
@@ -1,0 +1,34 @@
+use confgr::prelude::*;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, Clone)]
+struct NonDefaultType {
+    value: String,
+}
+
+fn default_non_default_type() -> NonDefaultType {
+    NonDefaultType {
+        value: "default_value".to_string(),
+    }
+}
+
+#[derive(Config)]
+struct TestConfig {
+    #[config(skip)]
+    foreign_type: NonDefaultType,
+}
+
+impl Default for TestConfig {
+    fn default() -> Self {
+        Self {
+            foreign_type: default_non_default_type(),
+        }
+    }
+}
+
+#[test]
+fn test_non_default_foreign_type_is_valid() {
+    let config = TestConfig::load_config();
+    assert_eq!(config.foreign_type.value, "default_value");
+}
+


### PR DESCRIPTION
- Fixed logical error in `confgr_derive::convert`, to allow the use of types that don't implement `Default`.
- Added `foreign.rs` in tests to ensure the macro is compatible with non default types.
- Updated readme to correctly list field type trait bounds. ie. `Deserialize`, `Clone` and `Debug`.